### PR TITLE
bug fix: wrong result dimensions when query is a vector

### DIFF
--- a/R/nn.R
+++ b/R/nn.R
@@ -73,7 +73,7 @@ nn2 <- function(data, query=data, k=min(10,nrow(data)),treetype=c("kd","bd"),
   ND		    <- nrow(data)
   if(is.null(ND)) ND=length(data)
   NQ		    <- nrow(query)
-  if(is.null(NQ)) NQ=length(data)
+  if(is.null(NQ)) NQ=length(query)
   
   # Check that both datasets have same dimensionality
   if(query_dimension != query_dimension)


### PR DESCRIPTION
if query is a vector shouldn't the resulting dimensions be length of query instead of data?